### PR TITLE
Wstępna propozycja modyfikacji uzględniająca treść w formacie HTML.

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -12,9 +12,6 @@ from raven import Client
 def main():
     config = get_config(os.environ)
     session = requests.Session()
-    session.headers = {
-        'Content-Type': 'application/imap-to-webhook-v2+json'
-    }
     print("Configuration: ", config)
     if config['sentry_dsn']:
         sentry_client = Client(config['sentry_dsn'])

--- a/daemon.py
+++ b/daemon.py
@@ -13,7 +13,7 @@ def main():
     config = get_config(os.environ)
     session = requests.Session()
     session.headers = {
-        'Content-Type': 'application/imap-to-webhook-v1+json'
+        'Content-Type': 'application/imap-to-webhook-v2+json'
     }
     print("Configuration: ", config)
     if config['sentry_dsn']:

--- a/daemon.py
+++ b/daemon.py
@@ -51,10 +51,8 @@ def process_msg(client, msg_id, config, session, sentry_client=None):
         end = time.time()
         print("Message serialized in {} seconds".format(end - start))
         res = session.post(config['webhook'], files=body)
-        print(res.text)
         res.raise_for_status()
-        response = res.json()
-        
+        response = res.json()        
         print("Delivered message id {} :".format(msg_id), response)
         if config['imap']['on_success'] == 'delete':
             client.mark_delete(msg_id)

--- a/daemon.py
+++ b/daemon.py
@@ -12,6 +12,9 @@ from raven import Client
 def main():
     config = get_config(os.environ)
     session = requests.Session()
+    session.headers = {
+        'Content-Type': 'application/imap-to-webhook-v1+json'
+    }
     print("Configuration: ", config)
     if config['sentry_dsn']:
         sentry_client = Client(config['sentry_dsn'])

--- a/parser.py
+++ b/parser.py
@@ -26,6 +26,7 @@ GZ_MIME = 'application/gzip'
 EML_MIME = 'message/rfc822'
 BINARY_MIME = 'application/octet-stream'
 
+
 def get_text(mail):
     raw_content, html_content, plain_content, html_quote, plain_quote = '', '', '', '', ''
 
@@ -115,6 +116,7 @@ def get_eml(raw_mail, compress_eml):
         content = file.getvalue()
     return content
 
+
 def serialize_mail(raw_mail, compress_eml=False):
     mail = mailparser.parse_from_bytes(raw_mail)
     files = []
@@ -141,7 +143,7 @@ def serialize_mail(raw_mail, compress_eml=False):
     )
     # Build eml
     eml_ext = 'eml.gz' if compress_eml else 'eml'
-    eml_name =  "{}.{}".format(uuid.uuid4().hex, eml_ext)
+    eml_name = "{}.{}".format(uuid.uuid4().hex, eml_ext)
     eml_mime = GZ_MIME if compress_eml else EML_MIME
 
     files.append(

--- a/parser.py
+++ b/parser.py
@@ -132,6 +132,7 @@ def serialize_mail(raw_mail, compress_eml=False):
             'message_id': mail.message_id,
             'auto_reply_type': get_auto_reply_type(mail)
         },
+        'version': 'v2',
         'text': get_text(mail),
         'files_count': len(mail.attachments),
         'eml': {

--- a/parser.py
+++ b/parser.py
@@ -135,9 +135,9 @@ def serialize_mail(raw_mail, compress_eml=False):
         ('manifest', ('manifest.json', BytesIO(json.dumps(body).encode('utf-8')), JSON_MIME))
     )
     # Build eml
-    eml_ext = '.sql.gz' if compress_eml else '.gz'
-    eml_mime = GZ_MIME if compress_eml else EML_MIME
+    eml_ext = 'eml.gz' if compress_eml else 'eml'
     eml_name =  "{}.{}".format(uuid.uuid4().hex, eml_ext)
+    eml_mime = GZ_MIME if compress_eml else EML_MIME
 
     files.append(
         ('eml', (eml_name, BytesIO(get_eml(raw_mail, compress_eml)), eml_mime))

--- a/parser.py
+++ b/parser.py
@@ -11,6 +11,7 @@ import mailparser
 import talon
 from html2text import html2text
 
+
 talon.init()
 
 decoder_map = {
@@ -26,22 +27,26 @@ EML_MIME = 'message/rfc822'
 BINARY_MIME = 'application/octet-stream'
 
 def get_text(mail):
-    raw_content, content, quote = '', '', ''
+    raw_content, html_content, plain_content, html_quote, plain_quote = '', '', '', '', ''
 
     if mail.text_html:
-        raw_content = "".join(mail.text_html).replace("\r\n", "\n")
-        content = talon.quotations.extract_from_html(raw_content)
-        quote = raw_content.replace(content, '')
-        content = html2text(content)
+        raw_content = ''.join(mail.text_html).replace('\r\n', '\n')
+        html_content = talon.quotations.extract_from_html(raw_content)
+        html_quote = raw_content.replace(html_content, '')
+        plain_content = html2text(html_content)
 
-    if mail.text_plain or not content:
-        raw_content = "".join(mail.text_plain)
-        content = talon.quotations.extract_from_plain(raw_content)
-        quote = raw_content.replace(content, '')
+    if mail.text_plain or not plain_content:
+        raw_content = ''.join(mail.text_plain)
+        plain_content = talon.quotations.extract_from_plain(raw_content)
+        plain_quote = raw_content.replace(plain_content, '')
 
+    # 'content' item holds plain_content and 'quote' item holds plain_quote (with HTML stripped off).
+    # These names are used for backward compatibility.
     return {
-        'content': content,
-        'quote': quote
+        'html_content': html_content,
+        'content': plain_content,
+        'html_quote': html_quote,
+        'quote': plain_quote
     }
 
 
@@ -66,7 +71,7 @@ def get_to_plus(mail):
         match.group(1)
         for match in
         [
-            re.search('for ([a-zA-Z0-9\-]+@[a-zA-Z.]+)', r['others'])
+            re.search(r'for ([a-zA-Z0-9\-]+@[a-zA-Z.]+)', r['others'])
             for r in mail.received
             if 'others' in r
         ]

--- a/parser.py
+++ b/parser.py
@@ -12,7 +12,6 @@ import talon
 from html2text import html2text
 
 
-
 talon.init()
 
 decoder_map = {

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 import os
+import json
 import unittest
 
 from parser import serialize_mail
@@ -20,23 +21,29 @@ class TestMain(unittest.TestCase):
     def test_disposition_notification(self):
         mail = get_email_as_bytes('disposition-notification.eml')
         body = serialize_mail(mail)
+        body_map = {k:v for k, v in body}
+        manifest = json.loads(body_map['manifest'][1].read().decode('utf-8'))
         self.assertTrue(
-            body['headers']['auto_reply_type'],
+            manifest['headers']['auto_reply_type'],
             'disposition-notification'
         )
 
     def test_vacation_reply(self):
         mail = get_email_as_bytes('vacation-reply.eml')
         body = serialize_mail(mail)
+        body_map = {k:v for k, v in body}
+        manifest = json.loads(body_map['manifest'][1].read().decode('utf-8'))
         self.assertTrue(
-            body['headers']['auto_reply_type'],
+            manifest['headers']['auto_reply_type'],
             'vacation-reply'
         )
 
     def test_html_only(self):
         mail = get_email_as_bytes('html_only.eml')
         body = serialize_mail(mail)
-        self.assertTrue(body['text']['content'])
+        body_map = {k:v for k, v in body}
+        manifest = json.loads(body_map['manifest'][1].read().decode('utf-8'))
+        self.assertTrue(manifest['text']['content'])
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -44,6 +44,7 @@ class TestMain(unittest.TestCase):
         body_map = {k:v for k, v in body}
         manifest = json.loads(body_map['manifest'][1].read().decode('utf-8'))
         self.assertTrue(manifest['text']['content'])
+        self.assertTrue(manifest['text']['html_content'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Powinna być wstecznie kompatybilna, ponieważ pozostawia poprzedni format bez zmian, a dodaje tylko 2 nowe klucze do słownika wynikowego.

Message body serialization in two versions: plain text (always) and HTML (if available).